### PR TITLE
fix: unable to find updated linkerscript

### DIFF
--- a/armv7a-vexos-eabi.json
+++ b/armv7a-vexos-eabi.json
@@ -13,7 +13,7 @@
     "max-atomic-width": 64,
     "panic-strategy": "abort",
     "post-link-args": {
-        "ld.lld": ["--gc-sections", "--nostdlib", "-Tcold.ld", "-znorelro"]
+        "ld.lld": ["--gc-sections", "--nostdlib", "-Tv5.ld", "-znorelro"]
     },
     "relocation-model": "static",
     "target-pointer-width": "32",


### PR DESCRIPTION
broken since https://github.com/vexide/vexide/commit/78aec629edaf75e2f0e50d1f13d3efac45c4d625