### PR TITLE
partially fix: #3 update vexide-template for v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,15 @@ version = 3
 
 [[package]]
 name = "async-task"
-version = "4.7.0"
+version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bitflags"
@@ -57,15 +57,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135b08af27d103b0a51f2ae0f8632117b7b185ccf931445affa8df530576a41"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
  "num-complex",
  "num-integer",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -136,20 +136,19 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -176,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.80"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -191,6 +190,12 @@ checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "replace_with"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a8614ee435691de62bcffcf4a66d91b3594bf1428a5722e79103249a095690"
 
 [[package]]
 name = "scopeguard"
@@ -221,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.59"
+version = "2.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -232,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "talc"
-version = "4.4.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fd7baf7741cf3749967c73529ec946c09adcfb44a5256fa92f37623fcbda9f"
+checksum = "04be12ec299aadd63a0bf781d893e4b6139d33cdca6dcd6f6be31f849cedcac8"
 dependencies = [
  "lock_api",
 ]
@@ -260,7 +265,7 @@ checksum = "0b975ac9f3d592c4869e6096ef7d0f1bdc26f389fc66beafa0dfbc8a2f499d4a"
 [[package]]
 name = "vexide"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#08e6ae53ec6dfc01147d86f28fe2c9f93c764d37"
+source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
 dependencies = [
  "vex-sdk 0.12.3",
  "vexide-async",
@@ -275,7 +280,7 @@ dependencies = [
 [[package]]
 name = "vexide-async"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#08e6ae53ec6dfc01147d86f28fe2c9f93c764d37"
+source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
 dependencies = [
  "async-task",
  "critical-section",
@@ -287,7 +292,7 @@ dependencies = [
 [[package]]
 name = "vexide-core"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#08e6ae53ec6dfc01147d86f28fe2c9f93c764d37"
+source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
 dependencies = [
  "bitflags",
  "critical-section",
@@ -296,6 +301,7 @@ dependencies = [
  "lock_api",
  "no_std_io",
  "pin-project",
+ "replace_with",
  "snafu",
  "talc",
  "vex-sdk 0.12.3",
@@ -304,7 +310,7 @@ dependencies = [
 [[package]]
 name = "vexide-devices"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#08e6ae53ec6dfc01147d86f28fe2c9f93c764d37"
+source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
 dependencies = [
  "bitflags",
  "mint",
@@ -317,7 +323,7 @@ dependencies = [
 [[package]]
 name = "vexide-macro"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#08e6ae53ec6dfc01147d86f28fe2c9f93c764d37"
+source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
 dependencies = [
  "quote",
  "syn",
@@ -326,7 +332,7 @@ dependencies = [
 [[package]]
 name = "vexide-math"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#08e6ae53ec6dfc01147d86f28fe2c9f93c764d37"
+source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
 dependencies = [
  "num",
  "vexide-core",
@@ -335,7 +341,7 @@ dependencies = [
 [[package]]
 name = "vexide-panic"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#08e6ae53ec6dfc01147d86f28fe2c9f93c764d37"
+source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
 dependencies = [
  "vex-sdk 0.12.3",
  "vexide-core",
@@ -345,7 +351,7 @@ dependencies = [
 [[package]]
 name = "vexide-startup"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#08e6ae53ec6dfc01147d86f28fe2c9f93c764d37"
+source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
 dependencies = [
  "vex-sdk 0.12.3",
  "vexide-async",
@@ -367,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "waker-fn"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,8 @@ checksum = "0b975ac9f3d592c4869e6096ef7d0f1bdc26f389fc66beafa0dfbc8a2f499d4a"
 [[package]]
 name = "vexide"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0908b2427d99157425a0a21bf0176078dd2f4da67cf2682732ed247f5bae1dc2"
 dependencies = [
  "vex-sdk 0.12.3",
  "vexide-async",
@@ -280,7 +281,8 @@ dependencies = [
 [[package]]
 name = "vexide-async"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade8b959286c89b55d16decc62d65c9b39044abfd4037e6040ba23d545e6bf51"
 dependencies = [
  "async-task",
  "critical-section",
@@ -292,7 +294,8 @@ dependencies = [
 [[package]]
 name = "vexide-core"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf01212bdaa52945d1d8f74fd009664bd1e4482d27c1d1e11fb6e15cbd16e1b"
 dependencies = [
  "bitflags",
  "critical-section",
@@ -310,7 +313,8 @@ dependencies = [
 [[package]]
 name = "vexide-devices"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9021e27996f1e7b6473743880346ff78c5403680703c72b852f417e62bc78f"
 dependencies = [
  "bitflags",
  "mint",
@@ -323,7 +327,8 @@ dependencies = [
 [[package]]
 name = "vexide-macro"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fa52584b31c59d97254caf86c471e1fdc0fe140426313682eb12c0e3bf1f53"
 dependencies = [
  "quote",
  "syn",
@@ -332,7 +337,8 @@ dependencies = [
 [[package]]
 name = "vexide-math"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09234a2ce6dff60e52a76dedb9560e3bf94cad673d08be92a8ae87bc78de53e8"
 dependencies = [
  "num",
  "vexide-core",
@@ -341,7 +347,8 @@ dependencies = [
 [[package]]
 name = "vexide-panic"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8897751b47c4599e9556b10a4bf8381a485c91377c4ca63d2a2122cb285b8d77"
 dependencies = [
  "vex-sdk 0.12.3",
  "vexide-core",
@@ -351,7 +358,8 @@ dependencies = [
 [[package]]
 name = "vexide-startup"
 version = "0.1.0"
-source = "git+https://github.com/vexide/vexide.git?branch=main#6f48f111234b91a578b99ff60cdea1882b16b139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71f53543059c4c63b7390c2943d9e39661b2184e8d6f2dcf967383b3396bf1c2"
 dependencies = [
  "vex-sdk 0.12.3",
  "vexide-async",
@@ -366,9 +374,6 @@ dependencies = [
  "num-traits",
  "vex-sdk 0.11.0",
  "vexide",
- "vexide-async",
- "vexide-devices",
- "vexide-startup",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,5 @@ edition = "2021"
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
-vexide-startup = { git = "https://github.com/vexide/vexide.git", branch = "main" }
-vexide-async = { git = "https://github.com/vexide/vexide.git", branch = "main" }
-vexide-devices = { git = "https://github.com/vexide/vexide.git", branch = "main" }
-vexide = { git = "https://github.com/vexide/vexide.git", branch = "main" }
+vexide = "0.1.0"
 vex-sdk = "0.11.0"

--- a/armv7a-vexos-eabi.json
+++ b/armv7a-vexos-eabi.json
@@ -13,7 +13,12 @@
     "max-atomic-width": 64,
     "panic-strategy": "abort",
     "post-link-args": {
-        "ld.lld": ["--gc-sections", "--nostdlib", "-Tv5.ld", "-znorelro"]
+        "ld.lld": [
+            "--gc-sections",
+            "--nostdlib",
+            "-Tv5.ld",
+            "-znorelro"
+        ]
     },
     "relocation-model": "static",
     "target-pointer-width": "32",

--- a/src/drivetrain.rs
+++ b/src/drivetrain.rs
@@ -1,6 +1,5 @@
 use num_traits::Signed;
-use vexide::prelude::*;
-use vexide_devices::smart::motor::MotorError;
+use vexide::{devices::smart::motor::MotorError, prelude::*};
 
 /// Example implementation of a drivetrain subsystem.
 pub struct Drivetrain {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 extern crate alloc;
 
 use alloc::boxed::Box;
-use core::{error::Error, fmt::Write, time::Duration};
+use core::{error::Error, time::Duration};
 
 use vexide::prelude::*;
 


### PR DESCRIPTION
This will only fix the dependency section of #3, not the overuse of the `?` operator


I am working on a gh action to check for outdated dependencies and submit a PR if any are found